### PR TITLE
scrapingした際店舗1件につき4回スクレイピングされる不具合を修正

### DIFF
--- a/main.go
+++ b/main.go
@@ -7,11 +7,11 @@ import (
 
 type ShopDetail struct {
 	ShopName      string
-	PhoneNumber   string
 	ReserveStatus string
 	Address       string
 	Time          string
 	Payment       string
+	PhoneNumber   string
 	Cost          string
 }
 
@@ -30,14 +30,14 @@ func scraping(URL string) {
 		link := e.ChildAttr(".hyakumeiten-shop__target", "href")
 		detailCollector.Visit(e.Request.AbsoluteURL(link))
 	})
-	detailCollector.OnHTML(".rstinfo-table__table", func(e *colly.HTMLElement) {
+	detailCollector.OnHTML(".rstinfo-table", func(e *colly.HTMLElement) {
 		shopDetail := ShopDetail{
 			ShopName:      e.ChildText(".rstinfo-table__name-wrap"),
-			PhoneNumber:   e.ChildText(".rstinfo-table__tel-num"),
 			ReserveStatus: e.ChildText(".rstinfo-table__reserve-status"),
 			Address:       e.ChildText(".listlink"),
 			Time:          e.ChildText(".rstinfo-table__subject-text"),
 			Payment:       e.ChildText(".rstinfo-table__pay-item"),
+			PhoneNumber:   e.DOM.Find(".rstinfo-table__tel-num").First().Text(),
 			Cost:          e.DOM.Find(".gly-b-dinner").First().Text(),
 		}
 		shopDetails = append(shopDetails, shopDetail)


### PR DESCRIPTION
１つの店舗ページに.rstinfo-table__tableが４つあるためdetailCollector.OnHTML(".rstinfo-table__table", func(e *colly.HTMLElement) 
と指定すると1店舗につき4回スクレイピングされていた。
そのため指定するclass名を変更し
detailCollector.OnHTML(".rstinfo-table", func(e *colly.HTMLElement) {
のようにすることでバグを修正した

